### PR TITLE
Refactor adding custom code using Hugo Pipes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,56 @@ Use [RealFaviconGenerator](https://realfavicongenerator.net/) to generate these 
 
 ## How to configure
 
-The theme doesn't require any advanced configuration. Just copy:
+The theme doesn't require any advanced configuration. Just copy this code to ./config.toml
 
 ```
-baseurl = "/"
-languageCode = "en-us"
+baseURL = "https://example.com"
+title   = "Hello Friend NG"
+
+DefaultContentLanguage = "en"
+
 theme = "hello-friend-ng"
+
+pygmentsCodefences = true
+pygmentsUseClasses = true
+rssLimit  = 10  # Maximum number of items in the RSS feed.
+copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License." # This message is only used by the RSS template.
+
+# googleAnalytics = ""
+# disqusShortname = ""
+
+archetypeDir = "archetypes"
+contentDir   = "content"
+dataDir      = "data"
+layoutDir    = "layouts"
+publishDir   = "public"
+
+buildDrafts  = false
+buildFuture  = false
+buildExpored = false
+canonifyURLs = true
+
+enableRobotsTXT = true
+enableGitInfo   = false
+enableEmoji     = true
+enableMissingTranslationPlaceholders = false
+disableRSS     = false
+disableSitemap = false
+disable404     = false
+disableHugoGeneratorInject = false
+
+[permalinks]
+  posts = "/posts/:year/:month/:title/"
+
+[author]
+  name = "Jane Doe"
+
+[blackfriday]
+  hrefTargetBlank = true
+
+[taxonomies]
+  tag      = "tags"
+  category = ""
 
 [params]
   dateform        = "Jan 2, 2006"
@@ -82,52 +126,66 @@ theme = "hello-friend-ng"
   dateformNumTime = "2006-01-02 15:04 -0700"
 
   # Metadata mostly used in document's head
-  description = "Homepage and blog by Djordje Atlialp"
-  keywords = "homepage, blog, science, informatics, development, programming"
+  description = "Nice theme for homepages and blogs"
+  keywords = ""
   images = [""]
+
+  homeSubtitle = "Hello Friend NG"
+
+  # Prefix of link to the git commit detail page. GitInfo must be enabled.
+  # gitUrl = ""
+
+  # Toggle this option need to rebuild SCSS, requires extended version of Hugo
+  justifyContent = false  # Set "text-align: justify" to .content.
 
   # Directory name of your blog content (default is `content/posts`)
   contentTypeName = "posts"
   # Default theme "light" or "dark"
   defaultTheme = "dark"
+  themeColor = "#252627"
+
+  [params.logo]
+    logoText     = "$ cd /home/"
+    logoHomeLink = "/"
+
+  # Social icons
+  [[params.social]]
+    name = "twitter"
+    url  = "https://twitter.com/"
+
+  [[params.social]]
+    name = "email"
+    url  = "mailto:nobody@example.com"
+
+  [[params.social]]
+    name = "github"
+    url  = "https://github.com/"
+
+  [[params.social]]
+    name = "linkedin"
+    url  = "https://www.linkedin.com/"
 
 [languages]
   [languages.en]
-    title = "Hello Friend NG"
-    subtitle = "A simple theme for Hugo"
-    keywords = ""
-    copyright = ""
-    readOtherPosts = "Read other posts"
+    subtitle  = "Hello Friend NG Theme"
+    weight    = 1
+    copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
 
-    [languages.en.params.logo]
-      logoText = "hello friend ng"
-      logoHomeLink = "/"
-    # or
-    #
-    # path = "/img/your-example-logo.svg"
-    # alt = "Your example logo alt text"
+  [languages.fr]
+    subtitle  = "Hello Friend NG Theme"
+    weight    = 2
+    copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
 
-	# You can create a language based menu
-    [languages.en.menu]
-      [[languages.en.menu.main]]
-        identifier = "about"
-        name = "About"
-        url = "/about"
-      [[languages.en.menu.main]]
-        identifier = "showcase"
-        name = "Showcase"
-        url = "/showcase"
-
-# And you can even create generic menu
 [menu]
   [[menu.main]]
     identifier = "about"
     name       = "About"
-    url        = "/about"
+    url        = "about/"
   [[menu.main]]
-    identifier = "blog"
-    name       = "Blog"
-    url        = "/posts"
+    identifier = "posts"
+    name       = "Posts"
+    url        = "posts/"
+
 ```
 
 
@@ -156,6 +214,11 @@ and then run:
 $ npm install
 ```
 
+## How to add custom CSS or JS code
+
+This theme is configured to bundle any code in assets/JS/main.js or assets/SCSS/main.scss into your website using [Hugo Pipes](https://gohugo.io/hugo-pipes/introduction/).
+Simply create these folders and files and add your custom code there.
+
 
 ## How to contribute
 
@@ -167,6 +230,7 @@ If you spot any bugs, please use [Issue Tracker](https://github.com/rhazdon/hugo
   - [normalize.css](https://github.com/necolas/normalize.css)
   - [Feather Open Source Icons](https://github.com/feathericons/feather)
   - [Flag Icon](https://github.com/lipis/flag-icon-css)
+  - [Prism.js](https://prismjs.com/)
 
 
 ## Licence

--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -1,0 +1,15 @@
+@import "normalize";
+@import "prism";
+
+@import "variables";
+@import "mixins";
+@import "fonts";
+@import "buttons";
+
+@import "header";
+@import "logo";
+@import "menu";
+@import "main";
+@import "list";
+@import "single";
+@import "footer";

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,15 +1,1 @@
-@import "normalize";
-@import "prism";
-
-@import "variables";
-@import "mixins";
-@import "fonts";
-@import "buttons";
-
-@import "header";
-@import "logo";
-@import "menu";
-@import "main";
-@import "list";
-@import "single";
-@import "footer";
+// Some scss code could be here..

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -62,6 +62,11 @@ disableHugoGeneratorInject = false
   # Prefix of link to the git commit detail page. GitInfo must be enabled.
   # gitUrl = ""
 
+  # Integrate Javascript files or stylesheets by adding the url to the external assets or by
+  # linking local files with their path relative to the static folder, e.g. "css/styles.css"
+  customCSS = []
+  customJS  = []
+
   # Toggle this option need to rebuild SCSS, requires extended version of Hugo
   justifyContent = false  # Set "text-align: justify" to .content.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -62,11 +62,6 @@ disableHugoGeneratorInject = false
   # Prefix of link to the git commit detail page. GitInfo must be enabled.
   # gitUrl = ""
 
-  # Integrate Javascript files or stylesheets by adding the url to the external assets or by
-  # linking local files with their path relative to the static folder, e.g. "css/styles.css"
-  customCSS = []
-  customJS  = []
-
   # Toggle this option need to rebuild SCSS, requires extended version of Hugo
   justifyContent = false  # Set "text-align: justify" to .content.
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,11 +11,6 @@
     </div>
     <div class="footer__inner">
         <div class="footer__content">
-
-        </div>
-    </div>
-    <div class="footer__inner">
-        <div class="footer__content">
             <span>Powered by <a href="http://gohugo.io">Hugo</a></span>
             <span>Made with &#10084; by <a href="https://github.com/rhazdon">rhazdon</a></span>
         </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,6 +31,12 @@
 {{ $style := $scss | toCSS | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $style.Permalink }}">
 
+{{ range $val := $.Site.Params.customCSS }}
+    {{ if gt (len $val) 0 }}
+        <link rel="stylesheet" type="text/css" href="{{ $val }}">
+    {{ end }}
+{{ end }}
+
 <!-- Icons -->
 {{- partial "favicons.html" }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,14 +25,11 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet"
     type="text/css">
 
-{{ $style := resources.Get "scss/main.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+{{ $base := resources.Get "scss/base.scss" }}
+{{ $main := resources.Get "scss/main.scss" }}
+{{ $scss := slice $base $main | resources.Concat "scss/main.scss" }}
+{{ $style := $scss | toCSS | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $style.Permalink }}">
-
-{{ range $val := $.Site.Params.customCSS }}
-{{ if gt (len $val) 0 }}
-<link rel="stylesheet" type="text/css" href="{{ $val }}">
-{{ end }}
-{{ end }}
 
 <!-- Icons -->
 {{- partial "favicons.html" }}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -17,3 +17,9 @@
         ga('send', 'pageview');
     </script>
 {{- end}}
+
+{{ range $val := $.Site.Params.customJS }}
+	{{ if gt (len $val) 0 }}
+		<script src="{{ $val }}"></script>
+	{{ end }}
+{{ end }}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -3,8 +3,9 @@
 {{ $prism := resources.Get "js/prism.js" }}
 {{ $theme := resources.Get "js/theme.js" }}
 {{ $js := slice $main $menu $prism $theme | resources.Concat "js/bundle.js" }}
-{{ $secureJS := $js | resources.Fingerprint "sha512" }}
-<script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+{{ $secureJS := $js | minify | fingerprint }}
+<script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"
+    crossorigin="anonymous"></script>
 
 {{- if .Site.GoogleAnalytics }}
     <script>
@@ -16,9 +17,3 @@
         ga('send', 'pageview');
     </script>
 {{- end}}
-
-{{ range $val := $.Site.Params.customJS }}
-	{{ if gt (len $val) 0 }}
-		<script src="{{ $val }}"></script>
-	{{ end }}
-{{ end }}


### PR DESCRIPTION
I liked the way of adding custom CSS or JS code but it wasn't consistent with the way the theme does it. Users can now add any code to /assets/js/main.js or /assets/scss/main.scss and it will be bundled with the rest of the code. 

This prevents having multiple:
`<script type="text/javascript" src="" integrity=""></script>`

Refactors #4 
Feedback wanted!