### PR TITLE
Updating to make post title it's H1 on single page

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -15,7 +15,7 @@
         </div>
 
         <article>
-            <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
+            <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
 
             {{- if .Params.toc }}
                 <hr />


### PR DESCRIPTION
Right now there wasn't an H1 at all, and the title was written out as a H2. Ideally we'd have the H1 be the main subject of the page (the post title seems appropriate for that), the first heading and there would be only the one H1.