### PR TITLE
sass: make logo font monospaced

### DIFF
--- a/assets/scss/_logo.scss
+++ b/assets/scss/_logo.scss
@@ -3,6 +3,7 @@
   align-items: center;
   text-decoration: none;
   font-weight: bold;
+  font-family: monospace, monospace;
 
   img {
     height: 44px;


### PR DESCRIPTION
Since the logo text wants to have the look and feel of a terminal, make the font `monospaced`.

The monospace word is used twice because of this hack:
https://stackoverflow.com/questions/38781089/font-family-monospace-monospace