### PR TITLE
Added font-display: auto to _fonts.scss

### DIFF
--- a/assets/scss/_fonts.scss
+++ b/assets/scss/_fonts.scss
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  normal;
+  font-display: auto;
   font-weight: 400;
   src: url("../fonts/Inter-UI-Regular.woff2") format("woff2"),
        url("../fonts/Inter-UI-Regular.woff") format("woff");
@@ -8,6 +9,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  italic;
+  font-display: auto;
   font-weight: 400;
   src: url("../fonts/Inter-UI-Italic.woff2") format("woff2"),
        url("../fonts/Inter-UI-Italic.woff") format("woff");
@@ -16,6 +18,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  normal;
+  font-display: auto;
   font-weight: 600;
   src: url("../fonts/Inter-UI-Medium.woff2") format("woff2"),
        url("../fonts/Inter-UI-Medium.woff") format("woff");
@@ -23,6 +26,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  italic;
+  font-display: auto;
   font-weight: 600;
   src: url("../fonts/Inter-UI-MediumItalic.woff2") format("woff2"),
        url("../fonts/Inter-UI-MediumItalic.woff") format("woff");
@@ -31,6 +35,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  normal;
+  font-display: auto;
   font-weight: 800;
   src: url("../fonts/Inter-UI-Bold.woff2") format("woff2"),
        url("../fonts/Inter-UI-Bold.woff") format("woff");
@@ -38,6 +43,7 @@
 @font-face {
   font-family: 'Inter UI';
   font-style:  italic;
+  font-display: auto;
   font-weight: 800;
   src: url("../fonts/Inter-UI-BoldItalic.woff2") format("woff2"),
        url("../fonts/Inter-UI-BoldItalic.woff") format("woff");


### PR DESCRIPTION
font-display on `auto` makes sure that the text is always
visible for the user. It's a suggestion by Googles PageSpeed Insights
to activate this feature:

https://developers.google.com/web/updates/2016/02/font-display?utm_source=lighthouse&utm_medium=unknown

Signed-off-by: Christian Rebischke <chris@nullday.de>