### PR TITLE
Set container flex-basis to auto

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -222,7 +222,7 @@ ol ol {
 }
 
 .container {
-  flex: 1;
+  flex: 1 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Without flex-basis: auto, IE overlays the footer on top of long pages of text,
as its position seems to be computed relative to the initial viewport.

I haven't tested this thoroughly but it doesn't seem to affect modern FF, Chrome, or Edge, and fixes the issue in IE 11.