### PR TITLE
Changed i18n file comment heading

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,4 +1,4 @@
-# Translations for France
+# Translations for French
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
 # Generic


### PR DESCRIPTION
# :fr: France ≠ French

1. In the locale file for other languages, the language name is used instead of a nation's name.
https://github.com/rhazdon/hugo-theme-hello-friend-ng/blob/091ba7b1d2836ebf1defa1908020524174df6353/i18n/en.toml#L1
https://github.com/rhazdon/hugo-theme-hello-friend-ng/blob/091ba7b1d2836ebf1defa1908020524174df6353/i18n/es.toml#L1
https://github.com/rhazdon/hugo-theme-hello-friend-ng/blob/091ba7b1d2836ebf1defa1908020524174df6353/i18n/pt-br.toml#L1
2. A country doesn't represent a language.  For instance, an Austrian German speaker has imformed me of the differences between the language used in :austria: Austria and in :de: Germany.
3. The French lanugage (for numbers) differs across countries.
https://fr.wikipedia.org/wiki/Nombres_en_fran%C3%A7ais#France,_Canada_et_les_pays_d'Afrique_francophones