### PR TITLE
Cursor color customization

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -80,6 +80,8 @@ disableHugoGeneratorInject = false
   [params.logo]
     logoText     = "$ cd /home/"
     logoHomeLink = "/"
+    # Set to a valid CSS color to change the cursor in the logo.
+    # logoColor    = "#67a2c9"
 
   # Social icons
   [[params.social]]

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -5,7 +5,7 @@
         {{ else }}
             <span class="logo__mark">></span>
             <span class="logo__text">{{ with .Site.Params.Logo.logoText }}{{ . }}{{ else }}hello{{ end }}</span>
-            <span class="logo__cursor"></span>
+            <span class="logo__cursor" style="{{ with .Site.Params.Logo.logoColor }}background-color:{{ . }}{{ end }}"></span>
         {{ end }}
     </div>
 </a>


### PR DESCRIPTION
Added parameter to customize the color of the cursor in the logo.
The same can be achieved by using a CSS file and adding it to the customCSS parameter, but it could be considered too much trouble for something that should be trivial.