### PR TITLE
Added option to disable Read Other Posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,6 +34,9 @@ disableSitemap = false
 disable404     = false
 disableHugoGeneratorInject = false
 
+# Set disableReadOtherPosts to true in order to hide the links to other posts.
+disableReadOtherPosts = false
+
 [permalinks]
   posts = "/posts/:year/:month/:title/"
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -56,7 +56,7 @@
             {{- end }}
         </div>
 
-        {{ if or .NextInSection .PrevInSection }}
+        {{ if and (not .Site.DisableReadOtherPosts) (or .NextInSection .PrevInSection) }}
             <div class="pagination">
                 <div class="pagination__title">
                     <span class="pagination__title-h">{{ .Site.Params.ReadOtherPosts }}</span>


### PR DESCRIPTION
I was thinking about using a variable like `showOtherPosts` in order to display the "Read Other Posts" section, but that would break backwards compatibility.
By setting `disableReadOtherPosts = true` that section will be hidden for all posts in the site.