### PR TITLE
add customJS parameter in front matter

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,6 +5,8 @@
             {{ if .Site.Author.name }}
                 <span><a href="{{ .Site.BaseURL }}">{{ .Site.Author.name }}</a></span>
             {{ end }}
+            <!-- refactor this -->
+            <span><a href="/privacy-statement">Privacy Policy</a></span>
             <span>{{ .Site.Copyright| safeHTML }}</span>
             <span>{{- with (not (in (.Site.Language.Get "disableKinds") "RSS")) }} <a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a>{{ end }}</span>
         </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,7 @@
 {{ block "title" . }}
     <title>
         {{ if .IsHome }}
-            {{ $.Site.Title }} {{ with $.Site.Params.Subtitle }} — {{ . }} {{ end }}
+            {{ $.Site.Params.headTitle }} {{ with $.Site.Params.Subtitle }} — {{ . }} {{ end }}
         {{ else }}
             {{ .Title }} :: {{ $.Site.Title }} {{ with $.Site.Params.Subtitle }} — {{ . }}{{ end }}
         {{ end }}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -16,8 +16,16 @@
     </script>
 {{- end}}
 
+<!-- Global JS -->
 {{ range $val := $.Site.Params.customJS }}
 	{{ if gt (len $val) 0 }}
 		<script src="{{ $val }}"></script>
 	{{ end }}
+{{ end }}
+
+<!-- Local JS -->
+{{ range $val := $.Params.customJS }}
+    {{ if gt (len $val) 0 }}
+        <script src="{{ $val }}"></script>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
Have the ability to inject JS scripts into specific pages, instead of having JS scripts loaded on every page. `customJS` expects a list of JS `src` values and can be used inside the front matter.

I added this change because, in my specific case, I wanted to use a Latex library (ex. MathJax) for a blog post, but I didn't want to load it on every page.