### PR TITLE
Align how the theme handles cover images

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
             {{- end }}
 
             {{ with .Params.Cover }}
-                <img src="/img/{{ . }}" class="post-cover" />
+                <img src="/{{ . }}" class="post-cover" />
             {{ end }}
 
             <div class="post-content">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -29,7 +29,7 @@
             {{- end }}
 
             {{ with .Params.Cover }}
-                <img src="/img/{{ . }}" class="post-cover" />
+                <img src="/{{ . }}" class="post-cover" />
             {{ end }}
 
             <div class="post-content">


### PR DESCRIPTION
The internal templates (e.g., `_internal/twitter_cards.html`) have a divergent methodology for handling the cover images than the theme does. 

As currently structured the them is also quite opinionated that images are located in the `img` dir. Removing the `img/` in the cover allows for a more flexible positioning of image files in the static directory, but also (and for my purposes more importantly) allows me to DRY up my yaml front matter. 

For me, and I suspect most users, it would be most frequent that the cover image would also be the image we'd want in twitter cards and opengraph (facebook/linkedin) sharing. With the current system my front matter looks like this;

```yaml
cover: 2020/test.jpg
images: 
- img/2020/test.jpg
```

However with the minor (admittedly breaking) change below I can do this:

```yaml
cover: &image img/2020/introduce.jpg
images: 
- *image
```

I also template those anchors in my `archetypes/post.md`. 

For me the above is much more helpful that it is DRY. I can also see that this would be a breaking change for users so I thought I would propose it with no expectation that it gets upstream. 