### PR TITLE
Fix typo 

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,7 +22,7 @@ publishDir   = "public"
 
 buildDrafts  = false
 buildFuture  = false
-buildExpored = false
+buildExpired = false
 canonifyURLs = true
 
 enableRobotsTXT = true


### PR DESCRIPTION
I just thought it should be  
`buildExpored` -> `buildExpired`

according to https://gohugo.io/getting-started/configuration/ 

( sorry for trivial pull request )

Thank for a very good work.