### PR TITLE
Footer adjustable with Params

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,8 +13,8 @@
     </div>
     <div class="footer__inner">
         <div class="footer__content">
-            <span>Powered by <a href="http://gohugo.io">Hugo</a></span>
-            <span>Made with &#10084; by <a href="https://github.com/rhazdon">Djordje Atlialp</a></span>
-        </div>
+            <span>{{ .Site.Params.footerLeft | default "Powered by <a href=\"http://gohugo.io\">Hugo</a>" | safeHTML }}</span>
+            <span>{{ .Site.Params.footerRight | default "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>" | safeHTML }}</span>
+          </div>
     </div>
 </footer>


### PR DESCRIPTION
This patch allows usage of `footerLeft` and `footerRight` params to override the bottom footer section. If not provided, the default is the previous static value.

Possibly could use better variable names, but the patch functions well on my demo page.