### PR TITLE
Use relURL for post-cover

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
             {{- end }}
 
             {{ with .Params.Cover }}
-                <img src="/{{ . }}" class="post-cover" />
+                <img src="{{ . | relURL }}" class="post-cover" />
             {{ end }}
 
             <div class="post-content">


### PR DESCRIPTION
Use relURL instead of statically adding a / in front of the path.  
Otherwise, this would give issues with external URLs. Also assumes user would know that a / is added in front of the path, making it relative to the root.