### PR TITLE
support for nickname

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -58,6 +58,7 @@ disableHugoGeneratorInject = false
   keywords = ""
   images = [""]
 
+  # nickname = "Use me if you want to differentiate between Title and the name displayed in the home page"
   homeSubtitle = "Hello Friend NG"
 
   # Prefix of link to the git commit detail page. GitInfo must be enabled.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,7 +5,13 @@
                <img src="{{ .Site.Params.Portrait.Path }}" class="circle" alt="{{ .Site.Params.Portrait.Alt }}" style="max-width:{{ .Site.Params.Portrait.MaxWidth }}" />
             {{ end }}
 
-            <h1>{{ .Site.Title }}</h1>
+            <h1>
+                {{ if .Site.Params.nickname }}
+                {{ .Site.Params.nickname }}
+                {{ else }}
+                {{ .Site.Title }}
+                {{ end }}
+            </h1>
             {{- with .Site.Params.homeSubtitle }}
                 <p>{{.}}</p>
             {{- end }}


### PR DESCRIPTION
Given the theme is aimed at personal sites, I think it's a good idea to have the possibility to differentiate between the user's name and nickname.

For example, I'm using the code in this MR in my personal site because I changed the `logoText` to use my name, which is the same value I'm using as the site's title. And then, I'm displaying my nick at the center of the homepage.

So, I ended up with:

```
title = "John Doe"
[author]
  name = "John Doe"
[params]
  nickname = "Mr. John"
  [params.logo]
    logoText = "John Doe"
```