### PR TITLE
Add Galician translation and flag

### DIFF
--- a/data/langFlags.yaml
+++ b/data/langFlags.yaml
@@ -9,3 +9,5 @@ nl: nl
 pt-br: br
 ru: ru
 tr: tr
+ml: in
+gl: es-ga

--- a/i18n/gl.toml
+++ b/i18n/gl.toml
@@ -1,0 +1,36 @@
+# Translations for Galician
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# Generic
+#
+[translations]
+other = "Traducións"
+
+[postAvailable]
+other = "Tamén dispoñible en"
+
+
+# 404.html
+#
+[archives]
+other = "Arquivos"
+
+[home]
+other = "Inicio"
+
+[notFound]
+other = "Vaia, non se atopou a páxina..."
+
+
+# posts/single.html
+#
+[readingTime]
+one   = "Un minuto"
+other = "{{ .Count }} minutos"
+
+[tableOfContents]
+other = "Táboa de contidos"
+
+[wordCount]
+one   = "Unha Palabra"
+other = "{{ .Count }} Palabras"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,7 +19,7 @@
 {{ end }}
 
 <!-- CSS -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet"
+<link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.5.0/css/flag-icon.min.css" rel="stylesheet"
     type="text/css">
 
 {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "enableSourceMap" true) }}


### PR DESCRIPTION
A PR containing:

- Translation (i18) for Galician language. (gl)
- Galician flag (es-ga) introduced in the last release of [lipis/flag-icon-css](https://github.com/lipis/flag-icon-css). ([Issue #405](https://github.com/lipis/flag-icon-css/pull/405)).