### PR TITLE
Fix hamburger icon flicker

### DIFF
--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -49,6 +49,11 @@
     fill: currentColor;
     margin-left: 10px;
     cursor: pointer;
+    display: none;
+
+    @media #{$media-size-phone} {
+      display: block;
+    }
   }
 
   a {


### PR DESCRIPTION
When you refresh the page you need to wait for all the JavaScript to be loaded in order for the hamburger icon to disappear. This PR hides the icon in css when not on mobile.