### PR TITLE
Enable relative path and caption in the post cover

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -31,8 +31,18 @@
         <hr />
       {{- end }}
 
-      {{ with .Params.Cover }}
-        <img src="/{{ . }}" class="post-cover" />
+      {{ if .Params.Cover }}
+        <figure class="post-cover">
+          {{ if .Params.UseRelativeCover }}
+            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+          {{ else }}
+            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
+          {{ end }}
+
+          {{ if .Params.CoverCaption }}
+            <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
+          {{ end }}
+        </figure>
       {{ end }}
 
       <div class="post-content">


### PR DESCRIPTION
## Problem
It is preferable to place the cover image in the same folder which the post is located(`content/posts/xxx/*.jpg`), instead of the `static` folder, so the image could go through the pipeline. But now if you want to set the cover to the image which is in the same directory as the post, it could only use the absolute path to set the cover.
## Solution
 I refer to the implementation in `panr/hugo-theme-hello-friend`, and create this PR.