### PR TITLE
Add multilingual menu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -4,5 +4,10 @@
         {{ range .Site.Menus.main -}}
             <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
         {{- end }}
+        {{ if .Site.IsMultiLingual }}
+            {{ range $.Translations }}
+                <li><a title="{{ .Language.LanguageName }}" href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
+            {{ end }}
+        {{ end }}
     </ul>
 </nav>


### PR DESCRIPTION
This PR adds a menu entry per each language available, except the current one. 

This only appears if the site is multilingual.