### PR TITLE
Added support for blog post audio.

### DIFF
--- a/assets/scss/_single.scss
+++ b/assets/scss/_single.scss
@@ -91,6 +91,17 @@
     }
   }
 
+  &-audio {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 20px;
+
+    audio {
+      width: 90%;
+    }
+  }
+
   .flag {
     border-radius: 50%;
     margin: 0 5px;

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -45,6 +45,14 @@
         <hr />
       {{- end }}
 
+      {{ if .Params.Audio }}
+        <div class="post-audio">
+          <audio controls>
+            <source src="{{ .Params.Audio }}">
+          </audio>
+        </div>
+      {{ end }}
+
       <div class="post-content">
         {{ .Content }}
       </div>


### PR DESCRIPTION
Just added an audio tag for blog posts, eg if someone wants to transcribe their blog post into an mp3 file and show it at the top of the page :slightly_smiling_face: 

On a post if you add the following
`audio: /test-file.mp3`

It will show the following: https://imgur.com/a/QViPMAO

Thanks for supporting this cool theme :+1: 
