### PR TITLE
Improve footer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -93,8 +93,12 @@ disableHugoGeneratorInject = false
   # Custom footer 
   # If you want, you can easily override the default footer with your own content. 
   #
-  # footerLeft = "Powered by <a href=\"http://gohugo.io\">Hugo</a>"
-  # footerRight = "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"
+  [params.footer]
+    rss = false
+    copyright = false
+    author = false
+    lowerText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>",
+                 "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"]
 
   # Colors for favicons
   #

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -94,11 +94,14 @@ disableHugoGeneratorInject = false
   # If you want, you can easily override the default footer with your own content. 
   #
   [params.footer]
+    trademark = false
     rss = false
     copyright = false
     author = false
-    lowerText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>",
-                 "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"]
+
+    topText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>"]
+    bottomText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>",
+            "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"]
 
   # Colors for favicons
   #

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -94,12 +94,12 @@ disableHugoGeneratorInject = false
   # If you want, you can easily override the default footer with your own content. 
   #
   [params.footer]
-    trademark = false
-    rss = false
-    copyright = false
-    author = false
+    trademark = true
+    rss = true
+    copyright = true
+    author = true
 
-    topText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>"]
+    topText = []
     bottomText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>",
             "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"]
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,15 +2,16 @@
     <div class="footer__inner">
         <div class="footer__content">
             <span>&copy; {{ now.Format "2006" }}</span>
-            {{ if .Site.Author.name }}<span><a href="{{ .Site.BaseURL }}">{{ .Site.Author.name }}</a></span>{{ end }}
-            {{ if .Site.Copyright }}<span>{{ .Site.Copyright| safeHTML }}</span>{{ end }}
-            {{- with (not (in (.Site.Language.Get "disableKinds") "RSS")) }}<span><a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a></span>{{ end }}
+            {{ if .Site.Params.footer.author }}<span><a href="{{ .Site.BaseURL }}">{{ .Site.Author.name }}</a></span>{{ end }}
+            {{ if .Site.Params.footer.copyright }}<span>{{ .Site.Copyright| safeHTML }}</span>{{ end }}
+            {{ if .Site.Params.footer.rss }}<span><a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a></span>{{ end }}
         </div>
     </div>
+    {{with .Site.Params.footer.lowerText}}
     <div class="footer__inner">
         <div class="footer__content">
-            <span>{{ .Site.Params.footerLeft | default "Powered by <a href=\"http://gohugo.io\">Hugo</a>" | safeHTML }}</span>
-            <span>{{ .Site.Params.footerRight | default "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>" | safeHTML }}</span>
-          </div>
+            {{ range . }}<span>{{ . | safeHTML}}</span>{{ end }}
+        </div>
     </div>
+    {{ end }}
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,13 +1,16 @@
 <footer class="footer">
+    {{if or (.Site.Params.footer.trademark) (.Site.Params.footer.author) (.Site.Params.footer.copyright) (.Site.Params.footer.rss) (.Site.Params.footer.topText) }}
     <div class="footer__inner">
         <div class="footer__content">
-            <span>&copy; {{ now.Format "2006" }}</span>
+            {{ if .Site.Params.footer.trademark }}<span>&copy; {{ now.Format "2006" }}</span>{{ end }}
             {{ if .Site.Params.footer.author }}<span><a href="{{ .Site.BaseURL }}">{{ .Site.Author.name }}</a></span>{{ end }}
             {{ if .Site.Params.footer.copyright }}<span>{{ .Site.Copyright| safeHTML }}</span>{{ end }}
             {{ if .Site.Params.footer.rss }}<span><a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a></span>{{ end }}
+            {{ range .Site.Params.footer.topText }}<span>{{ . | safeHTML}}</span>{{ end }}
         </div>
     </div>
-    {{with .Site.Params.footer.lowerText}}
+    {{ end }}
+    {{with .Site.Params.footer.bottomText}}
     <div class="footer__inner">
         <div class="footer__content">
             {{ range . }}<span>{{ . | safeHTML}}</span>{{ end }}


### PR DESCRIPTION
Hey everyone, 

I've been enjoying this theme for a while now and decided to contribute a bit more.
When customising the footer I noticed some odd behavior:

I wanted to remove the bottom half of the footer so configured the config.toml like so:
```
# footerLeft = ""
# footerRight = ""
```
Because its empty It would default to the same lines again because of the way its coded in the footer.html.
When I configued something like " " it would also be weird because it would still treat it as text and show the span like so:
![image](https://user-images.githubusercontent.com/14186884/107264791-b6f82180-6a43-11eb-9d33-d73a2537ad06.png)

This PR introduces a footer config that has a few features:
- Optional trademark
- Optional RSS
- Optional copyright
- Optional author name
- Optional custom text

Any feedback is appreciated!