### PR TITLE
Remove unnecessary padding in footer

### DIFF
--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -39,7 +39,7 @@
     }
 
     & > *:last-child {
-      padding: 0 5px;
+      padding: 0 0px;
 
       @media #{$media-size-tablet} {
           padding: 0;


### PR DESCRIPTION
There is some unnecessary padding in the footer as shown here:

![footer](https://user-images.githubusercontent.com/33134232/108111501-9a627780-7049-11eb-8605-d3cd4df6d647.png)

Note that this only occurs on the last-child on each line of the footer. This fix makes it even!
