### PR TITLE
make tags partial reusable with different parameters

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -41,7 +41,7 @@
         <hr />
 
         <div class="post-info">
-            {{ partial "tags.html" . }}
+            {{ partial "tags.html" .Params.tags }}
             {{ partial "categories.html" . }}
 
             {{- if .GitInfo }}

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,4 +1,4 @@
-{{ with .Params.tags }}
+{{ with . }}
     <p>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag meta-icon"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7" y2="7"></line></svg>
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -53,7 +53,7 @@
     <hr />
 
     <div class="post-info">
-      {{ partial "tags.html" . }}
+      {{ partial "tags.html" .Params.tags }}
       {{ partial "categories.html" . }}
 
       <p>


### PR DESCRIPTION
Just another quick change. So instead of hardcoding `.Params.tags` in `tags.html` we allow it to be reusable in different places. I'd like to render tags in my custom `list.html` view and it would be awesome to re-use the partial for theme default way of rendering tags.