### PR TITLE
Improved alignment of icons on 404 page

### DIFF
--- a/assets/scss/_404.scss
+++ b/assets/scss/_404.scss
@@ -1,0 +1,9 @@
+.btn-404 svg {
+  vertical-align: middle;
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.btn-404 a {
+  margin: 0 10px;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -16,3 +16,4 @@
 @import "footer";
 @import "sharing-buttons";
 @import "tables";
+@import "404";

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -7,8 +7,14 @@
             <h1>404</h1>
             <p>{{ i18n "notFound" }}</p>
             <p class="btn-404">
-                <a href="{{.Site.BaseURL}}"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-home"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>{{ i18n "home" }}</a>
-                <a href="{{ "posts" | absLangURL }}"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-archive"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>{{ i18n "archives" }}</a>
+                <a href="{{.Site.BaseURL}}">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-home"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
+                  {{- i18n "home" -}}
+                </a>
+                <a href="{{ "posts" | absLangURL }}">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-archive"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>
+                  {{- i18n "archives" -}}
+                </a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
This PR fixes some weird alignment issues on the icons on the 404 page.

It only makes an aesthetic change, so no site changes to configuration or site are needed.

Apologies for the different sized images, but here is a before and after:

**Before:**
 ![Before](https://i.imgur.com/PVs2c3n.png)

**After:** 
![After](https://i.imgur.com/rXhm3Mw.png)

If you want to see it in various browsers, it is deployed here: https://abyss.dev/404.html