### PR TITLE
Add defaultTheme option to override OS choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,29 @@ This theme was highly inspired by the [hello-friend](https://github.com/panr/hug
 
 ## Table of Contents
 
-- [Features](#features)
-- [How to start](#how-to-start)
-- [How to configure](#how-to-configure)
-- [More](#more-things)
-  - [Built in shortcodes](#built-in-shortcodes)
-    - [image](#image)
-  - [Code highlighting](#code-highlighting)
-  - [Favicon](#favicon)
-  - [Audio Support](#audio-support)
-- [Social Icons](#social-icons)
-- [Known issues](#known-issues)
-- [How to edit the theme](#how-to-edit-the-theme)
-- [Changelog](CHANGELOG.md)
-- [Sponsoring](#sponsoring)
-- [Licence](#licence)
+- [Hello Friend NG](#hello-friend-ng)
+  - [General informations](#general-informations)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+  - [How to start](#how-to-start)
+  - [How to configure](#how-to-configure)
+  - [More things](#more-things)
+    - [Built-in shortcodes](#built-in-shortcodes)
+      - [image](#image)
+    - [Code highlighting](#code-highlighting)
+    - [Favicon](#favicon)
+    - [Audio Support](#audio-support)
+  - [Social Icons](#social-icons)
+  - [Known issues](#known-issues)
+  - [How to edit the theme](#how-to-edit-the-theme)
+  - [Sponsoring](#sponsoring)
+  - [License](#license)
 
 ---
 
 ## Features
 
-- Theming: **dark/light mode**, depending on your system preferences or the users choice
+- Theming: **dark/light mode**, set by the site, operating system, or the users choice with optional theme toggle.
 - Great reading experience thanks to [**Inter UI font**](https://rsms.me/inter/), made by [Rasmus Andersson](https://rsms.me/about/)
 - Nice code highlighting thanks to [**PrismJS**](https://prismjs.com)
 - An easy way to modify the theme with Hugo tooling
@@ -162,7 +164,7 @@ In your article add to your front matters part:
 audio: path/to/file.mp3
 ```
 
-## Social Icons:
+## Social Icons
 
 A large variety of social icons are available and can be configured like this:
 
@@ -172,7 +174,7 @@ A large variety of social icons are available and can be configured like this:
   url = "<profile_URL>"
 ```
 
-Take a look into this [list](docs/svgs.md) of available icon options. 
+Take a look into this [list](docs/svgs.md) of available icon options.
 
 If you need another one, just open an issue or create a pull request with your wished icon. :)
 
@@ -198,7 +200,7 @@ Just edit it. You don't need any node stuff. ;)
 If you like my work and if you think this project is worth to support it, just <br />
 <a href="https://www.buymeacoffee.com/djordjeatlialp" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-green.png" alt="Buy Me A Coffee" style="height: 51px !important;width: 217px !important;" ></a>
 
-## Licence
+## License
 
 Copyright © 2019-2021 Djordje Atlialp
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,51 +1,20 @@
-/**
- * Theming.
- *
- * Supports the preferred color scheme of the operation system as well as
- * the theme choice of the user.
- *
- */
+// Theme Toggle
 const themeToggle = document.querySelector(".theme-toggle");
-const chosenTheme = window.localStorage && window.localStorage.getItem("theme");
-const chosenThemeIsDark = chosenTheme == "dark";
-const chosenThemeIsLight = chosenTheme == "light";
 
-// Detect the color scheme the operating system prefers.
-function detectOSColorTheme() {
-  if (chosenThemeIsDark) {
-    document.documentElement.setAttribute("data-theme", "dark");
-  } else if (chosenThemeIsLight) {
-    document.documentElement.setAttribute("data-theme", "light");
-  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-    document.documentElement.setAttribute("data-theme", "dark");
-  } else {
-    document.documentElement.setAttribute("data-theme", "light");
-  }
-}
-
-// Switch the theme.
-function switchTheme(e) {
-  if (chosenThemeIsDark) {
-    localStorage.setItem("theme", "light");
-  } else {
-    localStorage.setItem("theme", "dark");
-  }
-
-  detectOSColorTheme();
-  window.location.reload();
-}
-
-// Event listener
 if (themeToggle) {
   themeToggle.addEventListener("click", switchTheme, false);
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", (e) => e.matches && detectOSColorTheme());
-  window
-    .matchMedia("(prefers-color-scheme: light)")
-    .addEventListener("change", (e) => e.matches && detectOSColorTheme());
-
-  detectOSColorTheme();
 } else {
   localStorage.removeItem("theme");
+}
+
+// Switch the theme
+function switchTheme(e) {
+  const currentTheme = document.documentElement.getAttribute("data-theme");
+  if (currentTheme == "dark") {
+    localStorage.setItem("theme", "light");
+    document.documentElement.setAttribute("data-theme", "light")
+  } else {
+    localStorage.setItem("theme", "dark");
+    document.documentElement.setAttribute("data-theme", "dark")
+  }
 }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,24 @@
+/**
+ * Theming.
+ *
+ * Supports a tier of user choice, site choice, operating system.
+ *
+ */
+
+// Detect the color scheme the operating system prefers
+function detectOSColorTheme() {
+  if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  } else {
+    return "light";
+  }
+}
+
+// Set the initial theme based on the order of preference
+(() => {
+  const chosenTheme = window.localStorage && window.localStorage.getItem("theme");
+  const defaultTheme = document.documentElement.getAttribute("data-theme");
+  const osTheme = detectOSColorTheme();
+  const currentTheme = chosenTheme || defaultTheme || osTheme
+  document.documentElement.setAttribute("data-theme", currentTheme)
+})();

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -54,7 +54,7 @@ disableHugoGeneratorInject = false
   dateformNumTime = "2006-01-02 15:04"
 
   # Metadata mostly used in document's head
-  # 
+  #
   description = "Nice theme for homepages and blogs"
   keywords = ""
   images = [""]
@@ -75,12 +75,21 @@ disableHugoGeneratorInject = false
   disableReadOtherPosts = false
 
   # Enable theme toggle
-  # 
-  # This options enables the theme toggle for the theme. 
-  # Per default, this option is off. 
-  # The theme is respecting the prefers-color-scheme of the operating systeme. 
-  # With this option on, the page user is able to set the scheme he wants. 
+  #
+  # This options enables the theme toggle for the theme.
+  # Per default, this option is off.
+  # The theme is respecting the prefers-color-scheme of the operating systeme.
+  # With this option on, the page user is able to set the scheme he wants.
   enableThemeToggle = false
+
+  # Set a default theme
+  #
+  # This option allows you to set a default theme (light or dark) for the website.
+  # If this is not set, the browser will pick a theme based on OS settings
+  # If this is set to "dark" or "light", the site will be in that theme unless
+  # enableThemeToggle is on, and the user has changed the theme.
+  #
+  # defaultTheme = "dark"
 
   # Sharing buttons
   #
@@ -100,8 +109,8 @@ disableHugoGeneratorInject = false
   #
   justifyContent = false  # Set "text-align: justify" to .post-content.
 
-  # Custom footer 
-  # If you want, you can easily override the default footer with your own content. 
+  # Custom footer
+  # If you want, you can easily override the default footer with your own content.
   #
   [params.footer]
     trademark = true
@@ -131,11 +140,11 @@ disableHugoGeneratorInject = false
     # Set to a valid CSS time value to change the animation duration, "0s" to disable.
     # logoCursorAnimate  = "2s"
 
-  # Commento is more than just a comments widget you can embed — 
-  # it’s a return to the roots of the internet. 
-  # An internet without the tracking and invasions of privacy. 
-  # An internet that is simple and lightweight. 
-  # An internet that is focused on interesting discussions, not ads. 
+  # Commento is more than just a comments widget you can embed —
+  # it’s a return to the roots of the internet.
+  # An internet without the tracking and invasions of privacy.
+  # An internet that is simple and lightweight.
+  # An internet that is focused on interesting discussions, not ads.
   # A better internet.
   # Uncomment this to enable Commento.
   #

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language }}">
+<html lang="{{ .Site.Language }}" data-theme="{{ with .Site.Params.defaultTheme }}{{ . }}{{ end }}">
     <head>
         {{ partial "head.html" . }}
+        {{ partial "head.javascript.html" . }}
     </head>
 
     {{ block "body" . }}
         <body>
     {{ end }}
-    
+
         <div class="container">
             {{ partial "header.html" . }}
 

--- a/layouts/partials/head.javascript.html
+++ b/layouts/partials/head.javascript.html
@@ -1,0 +1,2 @@
+{{ $theme := resources.Get "js/theme.js" | resources.Minify | resources.Fingerprint "sha512" }}
+<script type="text/javascript" src="{{ $theme.RelPermalink }}" integrity="{{ $theme.Data.Integrity }}"></script>


### PR DESCRIPTION
# Introduction
This is a PR that re-adds the (optional!) ability to have a defaultTheme, as before the new theming rework.

# Behavior
If defaultTheme is not set, the behavior is unchanged from the current master branch.
If defaultTheme is set to "light" or "dark", that will be used before the OS theme.

**Order of priority**: 
- User Choice (if themeToggle is on, and they've clicked it at least once)
- defaultTheme (if set)
- OS theme (as current)

# Documentation
I've added documentation to both exampleSite's config and updated the primary README to account for this feature.

### Bonus
As a side effect, the Table of Contents was regenerated to be fully accurate to the README by my tooling, and I threw in a bonus spelling fix on License.

# Compatibility
This should be fully compatible with current configurations with no changes, with one caveat: if a user still has "defaultTheme" in their configuration, it will begin to work again.

# Breaking Changes
Also, there is one very minor feature that was dropped because I'm not quite sure the best way to implement it:
```js
  window
    .matchMedia("(prefers-color-scheme: dark)")
    .addEventListener("change", (e) => e.matches && detectOSColorTheme());
  window
    .matchMedia("(prefers-color-scheme: light)")
    .addEventListener("change", (e) => e.matches && detectOSColorTheme());
```
These two listeners are now gone - my understanding is these would only update the theme if the OS Color theme changed while the site was open. This seems like a fairly rare edge case, and given it's a static site I'm not sure users would expect the website's theme to update dynamically.

Of course, this could be edited back in, if you can think of an elegant way to implement it (the problem is I can't think of a good check for if the current theme is set by the site config, user, or OS - this code should only be present in the last case).

# Demo
This is in use at https://abyss.dev if you want to demo - it is set to have a defaultTheme of "dark", with themeToggle set to true.

# Conclusion
Of course, this is a fairly substantial change, so feel free to tweak the commits or give feedback as needed. :)
