### PR TITLE
Support relative paths for the cover image

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -28,8 +28,12 @@
 
       {{ if .Params.Cover }}
         <figure class="post-cover">
-          <img src="{{ .Params.Cover | absURL }}" alt="{{ .Title }}" />
-          
+          {{ if (or (fileExists (path.Join "static" .Params.Cover)) (hasPrefix .Params.Cover "http://") (hasPrefix .Params.Cover "https://")) }}
+            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Title }}" />
+          {{ else }}
+            <img src="{{ path.Join .RelPermalink .Params.Cover | absURL }}" alt="{{ .Title }}" />
+          {{ end }}
+
           {{ if .Params.CoverCaption }}
             <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
           {{ end }}


### PR DESCRIPTION
Add support for relative paths for cover images. This significantly helps with organising posts as cover images don't have to be stored in the `static` folder.

Addresses the unsolved part of #224.