### PR TITLE
Fix <pre> HTML tag to follow theme settings

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -239,7 +239,14 @@ code {
 }
 
 pre {
-  background: #212020;
+  [data-theme=dark] & {
+    background-color: $dark-background-secondary;
+  }
+
+  [data-theme=light] & {
+    background-color: $light-background-secondary;
+  }
+
   padding: 10px 10px 10px 20px;
   border-radius: 8px;
   font-size: 0.95rem;


### PR DESCRIPTION
The `<pre>` tag was set to a fixed background color that on the light
theme happened to be the same color of the text, making it impossible
to read.

This changes the background color to follow the theme setting using
the secondary light/dark color as background.