### PR TITLE
Fix rounded corners for cover images

### DIFF
--- a/assets/scss/_single.scss
+++ b/assets/scss/_single.scss
@@ -46,6 +46,7 @@
     margin: 40px -50px;
     width: $max-width;
     max-width: $max-width;
+    overflow: hidden;
     @media #{$media-size-tablet} {
       margin: 20px 0;
       width: 100%;


### PR DESCRIPTION
There were missing `overflow: hidden; ` for cover images. So all images has straight corners instead of rounded. (Another soutions is to move `border -radius` to `.cover img` element.

Withowt `overflow: hidden;`

![image](https://user-images.githubusercontent.com/3164256/136229812-04105e63-e32e-4c56-bfdb-748e05bc2fa3.png)

and this is how it looks like with it: 

![image](https://user-images.githubusercontent.com/3164256/136229971-9e3a2e67-616d-47ea-8d99-39f81d8b095a.png)
