### PR TITLE
Add site icon param for document head

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ paginate     = 10
   # Metadata mostly used in document's head
   description = "My new homepage or blog"
   keywords = "homepage, blog"
+  siteIcon = "assets/images/favicon.ico"
   images = [""]
 
 [taxonomies]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -58,6 +58,7 @@ disableHugoGeneratorInject = false
   description = "Nice theme for homepages and blogs"
   keywords = ""
   images = [""]
+  siteIcon = "assets/images/favicon.ico"
 
   # Home subtitle of the index page.
   #

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,10 @@
 <meta name="theme-color" content="{{ .Site.Params.themeColor }}" />
 <link rel="canonical" href="{{ .Permalink }}" />
 
+{{ if .Site.Params.siteIcon }}
+<link rel="icon" href="{{ .Site.Params.siteIcon }}" />
+{{ end }}
+
 {{ block "title" . }}
     <title>
         {{ if .IsHome }}


### PR DESCRIPTION
This will allow theme users to directly to set their site icon via the `siteIcon `param like so:

```toml
# config.toml
[params]
 # Path with respect to the static folder
  siteIcon = "/images/favicon.ico"
```

 Rather than each user creating  the extra-head.html to add an icon head,  I sensed it should be built in, just like the site description param  is.

Result:

 - Before:
![before](https://user-images.githubusercontent.com/64139733/142780501-0cadbe3c-d662-4c36-b260-d13b089e66a5.PNG)

- after: 
![after](https://user-images.githubusercontent.com/64139733/142780558-dda15630-c8d5-4a45-828c-67e3a5e5b5d3.PNG)


