### PR TITLE
Make it easier to override subtitle

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,9 +10,8 @@
             {{ end }}
 
             <h1>{{ .Site.Title }}</h1>
-            {{- with .Site.Params.homeSubtitle }}
-                <p>{{.}}</p>
-            {{- end }}
+
+            {{ partial "subtitle.html" . }}
 
             {{- with .Site.Params.social }}
                 <div>

--- a/layouts/partials/subtitle.html
+++ b/layouts/partials/subtitle.html
@@ -1,0 +1,3 @@
+{{- with .Site.Params.homeSubtitle }}
+    <p>{{.}}</p>
+{{- end }}


### PR DESCRIPTION
Creating a separate partial allows users to customize the subtitle without overriding whole index file