### PR TITLE
Fix unintentional render of empty box

### DIFF
--- a/layouts/partials/pagination-single.html
+++ b/layouts/partials/pagination-single.html
@@ -1,9 +1,11 @@
 {{ if and (not $.Site.Params.DisableReadOtherPosts) (or .NextInSection .PrevInSection) }}
     <div class="pagination">
+        {{ if .Site.Params.ReadOtherPosts }}
         <div class="pagination__title">
             <span class="pagination__title-h">{{ .Site.Params.ReadOtherPosts }}</span>
             <hr />
         </div>
+        {{ end }}
 
         <div class="pagination__buttons">
             {{ if .NextInSection }}


### PR DESCRIPTION
Fix rendering unneccessary box. It's visible when background color is changed or background is animated.

Empty box look like this on background:
![image](https://user-images.githubusercontent.com/15555035/147855605-85f46c24-5bc7-4dc8-9147-0ee2208d86a6.png)