### PR TITLE
Removes duplicate meta theme-color

### DIFF
--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -5,5 +5,3 @@
     <link rel="mask-icon" href="{{"safari-pinned-tab.svg" | relURL}}" color="{{.Site.Params.favicon.mask}}">
     <link rel="shortcut icon" href="{{"favicon.ico" | relURL}}">
     <meta name="msapplication-TileColor" content="{{.Site.Params.favicon.msapplication}}">
-    <meta name="theme-color" content="{{.Site.Params.favicon.theme}}">
-


### PR DESCRIPTION
Fixes issue #358 by removing `meta` tag `theme-color` from the `favicons.html` file because it is added from the `head.html` partial.

