### PR TITLE
Remove deprecated Google News internal template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,7 +37,6 @@
 
 {{ template "_internal/schema.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
-{{ template "_internal/google_news.html" . }}
 
 {{ if isset .Site.Taxonomies "series" }}
     {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
It is deprecated, as per https://github.com/gohugoio/hugo/issues/9172

Hugo shows this warning when building the site:
`WARN 2022/06/05 10:51:56 The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.
`