### PR TITLE
delimit raw URL in README for correct linking on themes.gohugo.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ paginate     = 10
 
 ### Built-in shortcodes
 
-Of course you are able to use all default shortcodes from hugo (https://gohugo.io/content-management/shortcodes/).
+Of course you are able to use all default shortcodes from hugo (<https://gohugo.io/content-management/shortcodes/>).
 
 #### image
 


### PR DESCRIPTION
Delimit raw URL in README, so that it links to https://gohugo.io/content-management/shortcodes/ rather than `https://gohugo.io/content-management/shortcodes/)` also on https://themes.gohugo.io/themes/hugo-theme-hello-friend-ng/#built-in-shortcodes, which seems to interpret the Markdown markup slightly different than GitHub does.