### PR TITLE
Added option for inline svg logo

### DIFF
--- a/assets/scss/_logo.scss
+++ b/assets/scss/_logo.scss
@@ -10,6 +10,10 @@
     height: 44px;
   }
 
+  svg {
+    height: 44px;
+  }
+
   &__mark {
     margin-right: 5px;
   }

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -2,6 +2,8 @@
     <div class="logo">
         {{ if .Site.Params.Logo.path }}
             <img src="{{ .Site.Params.Logo.path }}" alt="{{ .Site.Params.Logo.alt }}" />
+        {{ else if .Site.Params.Logo.svg }}
+            {{ partial .Site.Params.Logo.svg . }}
         {{ else }}
             <span class="logo__mark">{{ with .Site.Params.Logo.logoMark }}{{ . }}{{ else }}>{{ end }}</span>
             <span class="logo__text">{{ with .Site.Params.Logo.logoText }}{{ . }}{{ else }}hello{{ end }}</span>


### PR DESCRIPTION
This is needed to support a changing logo style depending on light/dark mode.

The svg logo has to be saved into the `layouts/partials/` folder as an html file.
To use that inline svg the following config has to be set:
```
[params.logo]
  svg = "logo_svg"
```
Where logo_svg.html is the file name within the partials folder.