### PR TITLE
Fixed first time theme change from dark mode

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,8 +27,14 @@ function detectOSColorTheme() {
 function switchTheme(e) {
   if (chosenThemeIsDark) {
     localStorage.setItem("theme", "light");
-  } else {
+  } else if (chosenThemeIsLight) {
     localStorage.setItem("theme", "dark");
+  } else {
+    if (document.documentElement.getAttribute("data-theme") == "dark") {
+      localStorage.setItem("theme", "light");
+    } else {
+      localStorage.setItem("theme", "dark");
+    }
   }
 
   detectOSColorTheme();


### PR DESCRIPTION
If the theme is detected as dark, the first click on the toggle theme button will now change to light mode.
Preveously no change would occur, since it would switch from default dark to force dark mode.