### PR TITLE
Improve styling to allow flexible overrides

### DIFF
--- a/assets/scss/_list.scss
+++ b/assets/scss/_list.scss
@@ -67,7 +67,7 @@
     &-item {
       border-bottom: 1px grey dashed;
 
-      a {
+      &-inner {
         display: flex;
         justify-content: space-between;
         align-items: baseline;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,7 +15,7 @@
                 <ul class="posts-list">
                     {{ range .Pages }}
                         <li class="post-item">
-                            <a href="{{.Permalink}}">
+                            <a href="{{.Permalink}}" class="post-item-inner">
                                 <span class="post-title">{{.Title}}</span>
                                 <span class="post-day">
                                     {{ if .Site.Params.dateformShort }}


### PR DESCRIPTION
This commit changes targeted styling of `a` element to a class-based styling. This way, this is style is reusable on other elements and another `<a>` element can be used inside a `post-item`.

Otherwise, if someone would need to use `<a>` element in a post item, then he would get all other styles (such as `display:flex`) on every `<a>` which is unexpected.

This commit ensures that the style is abstracted from the element type itself, giving more flexibility when overriding the theme, and increases maintainability by making the intent more clear.

This would save from a potential fix like this:
![image](https://user-images.githubusercontent.com/15555035/202052300-af9e0d0b-9b7b-41b3-aa28-1e45cce7508b.png)
To support scenarios like this:
![image](https://user-images.githubusercontent.com/15555035/202052613-a7e71805-2239-4e3c-80b2-2a9e13cb5da4.png)
