### PR TITLE
Fix squeezed logo text when menu title is long

### DIFF
--- a/assets/scss/_logo.scss
+++ b/assets/scss/_logo.scss
@@ -16,6 +16,7 @@
 
   &__text {
     font-size: 1.125rem;
+    white-space: nowrap;
   }
 
   &__cursor {


### PR DESCRIPTION
Logo text gets squeezed into very small area instead of taking place when a menu label is long. This commit fixes it by ensuring that it is not wrapped. This covers more cases and provides a good default for theme users.

Before:
![image](https://user-images.githubusercontent.com/15555035/202054276-362d3cda-d231-4bc3-8707-35ecf6d4e059.png)

After this fix:
![image](https://user-images.githubusercontent.com/15555035/202054291-e6830880-957c-46a0-b381-85edcf17e32f.png)
