### PR TITLE
Use ref function for building taxonomy URLs to support uglyURLs

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -41,7 +41,7 @@
         <hr />
 
         <div class="post-info">
-            {{ partial "tags.html" .Params.tags }}
+            {{ partial "tags.html" (dict "Page" . "tags" .Params.tags) }}
             {{ partial "categories.html" . }}
 
             {{- if .GitInfo }}

--- a/layouts/partials/categories.html
+++ b/layouts/partials/categories.html
@@ -3,7 +3,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-folder meta-icon"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
 
         {{ range . -}}
-            <span class="tag"><a href="{{ "categories/" | absLangURL }}{{ . | urlize }}/">{{.}}</a></span>
+            <span class="tag"><a href="{{ ref $.Page . }}">{{.}}</a></span>
         {{ end }}
     </p>
 {{ end }}

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,9 +1,9 @@
-{{ with . }}
+{{ with .tags }}
     <p>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag meta-icon"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7" y2="7"></line></svg>
 
         {{ range . -}}
-            <span class="tag"><a href="{{ "tags/" | absLangURL }}{{ . | urlize }}/">{{.}}</a></span>
+            <span class="tag"><a href="{{ ref $.Page . }}">{{.}}</a></span>
         {{ end }}
     </p>
 {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -61,7 +61,7 @@
     <hr />
 
     <div class="post-info">
-      {{ partial "tags.html" .Params.tags }}
+      {{ partial "tags.html" (dict "Page" . "tags" .Params.tags) }}
       {{ partial "categories.html" . }}
 
       <p>


### PR DESCRIPTION
Currently, the template assumes that `uglyURLs = false` and that URLs should end with `/`.
This MR changes links to use `rel` to generate the links instead to allow links to be rendered correctly regardless of the value for `uglyURLs`. 

Note that this imposes a restriction that there is no overlap between tags and categories (but Hugo may be enforcing this already).