### PR TITLE
Add rel=me for Mastodon verification

### DIFF
--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -1,3 +1,3 @@
 {{ range . -}}
-    &nbsp; <a href="{{ .url }}" target="_blank" rel="noopener {{ .rel }}" title="{{ .name | humanize }}">{{ partial "svg.html" . }}</a> &nbsp;
+    &nbsp; <a href="{{ .url }}" target="_blank" rel="me noopener {{ .rel }}" title="{{ .name | humanize }}">{{ partial "svg.html" . }}</a> &nbsp;
 {{- end -}}


### PR DESCRIPTION
This will add an attribute that will allow Mastodon users to get the ✅ on their profile when they add a mastodon social icon to their profile.