### PR TITLE
Add the global language switcher as a setting in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ paginate     = 10
 
   # Enable sharing buttons, if you like
   enableSharingButtons = true
+  
+  # Show a global language switcher in the navigation bar
+  enableGlobalLanguageMenu = true
 
   # Metadata mostly used in document's head
   description = "My new homepage or blog"


### PR DESCRIPTION
The readme mentions there being a setting to enable a global language menu, but doesn't show the setting itself.