### PR TITLE
Fix theme flickering/flashing during pages loading

### DIFF
--- a/assets/js/main_block.js
+++ b/assets/js/main_block.js
@@ -1,0 +1,5 @@
+// Update the local theme before rendering to avoid flickering
+
+if (localStorage.theme) {
+    document.documentElement.setAttribute("data-theme", localStorage.theme);
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
         {{ partial "head.html" . }}
         {{ if .Site.Params.EnableThemeToggle }}
         {{ partial "javascript_head.html" . }}
-	{{ end}}
+	{{ end }}
     </head>
 
     {{ block "body" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,12 +2,15 @@
 <html lang="{{ .Site.Language }}">
     <head>
         {{ partial "head.html" . }}
+        {{ if .Site.Params.EnableThemeToggle }}
+        {{ partial "javascript_head.html" . }}
+	{{ end}}
     </head>
 
     {{ block "body" . }}
         <body>
     {{ end }}
-    
+
         <div class="container">
             {{ partial "header.html" . }}
 

--- a/layouts/partials/javascript_head.html
+++ b/layouts/partials/javascript_head.html
@@ -1,0 +1,3 @@
+{{ $mainBlock := resources.Get "js/main_block.js" | resources.Minify | resources.Fingerprint "sha512" }}
+
+<script type="text/javascript" src="{{ $mainBlock.RelPermalink }}" integrity="{{ $mainBlock.Data.Integrity }}"></script>


### PR DESCRIPTION
When an user has opposite themes for their OS and the website, like OS dark and website light, it generates a flickering behaviour during loadings while browsing the website.

This fix this bug introducing a single line js inside the `<head>` to update the `data-theme` if there is a local `theme` defined by the user. Since this behaviour only happens when the user can toggle the theme, the single line script `main_block.js` is only deployed if the website config has the `EnableThemeToggle` set.

This addresses issue #429.

Tested locally and online. Working perfectly.