### PR TITLE
Hugo v112 deprecation warning

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -186,14 +186,16 @@ disableHugoGeneratorInject = false
 
 [languages]
   [languages.en]
-    subtitle  = "Hello Friend NG Theme"
     weight    = 1
     copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
+  [languages.en.params]
+    subtitle  = "Hello Friend NG Theme"
 
   [languages.fr]
-    subtitle  = "Hello Friend NG Theme"
     weight    = 2
     copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
+  [languages.fr.params]
+    subtitle  = "Hello Friend NG Theme"
 
 [menu]
   [[menu.main]]


### PR DESCRIPTION
Updated config.toml to avoid deprecation

Currently hugo show the following warning:

WARN  config: languages.en.subtitle: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

This pull  request aims to avoid problems in a future release.