### PR TITLE
Newer / older posts buttons not translated

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Wörter"
 
 [lastModified]
 other = "Letzte Aktualisierung"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Neuere Beiträge"
+olderPosts = "Ältere Beiträge"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Words"
 
 [lastModified]
 other = "Last updated"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Newer posts"
+olderPosts = "Older posts"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Palabras"
 
 [lastModified]
 other = "Ultima actualización"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Entradas más recientes"
+olderPosts = "Entradas antiguas"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Mots"
 
 [lastModified]
 other = "Mise à jour"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Articles plus récents"
+olderPosts = "Articles plus anciens"

--- a/i18n/gl.toml
+++ b/i18n/gl.toml
@@ -34,3 +34,8 @@ other = "Táboa de contidos"
 [wordCount]
 one   = "Unha Palabra"
 other = "{{ .Count }} Palabras"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Entradas más recientes"
+olderPosts = "Entradas antiguas"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Kata"
 
 [lastModified]
 other = "Terakhir diupdate"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Postingan yang lebih baru"
+olderPosts = "Postingan yang lebih lama"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} parole"
 
 [lastModified]
 other = "Ultimo aggiornamento"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Voci più recenti"
+olderPosts = "Voci più vecchie"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -1,4 +1,4 @@
-# Translations for English
+# Translations for Italian
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
 # Generic

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }}文字"
 
 [lastModified]
 other = "最終更新"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "新しいエントリー"
+olderPosts = "古いエントリー"

--- a/i18n/lmo.toml
+++ b/i18n/lmo.toml
@@ -1,4 +1,4 @@
-# Translations for English
+# Translations for Lombardian
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
 # Generic

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -1,4 +1,4 @@
-# Translations for Portuguese
+# Translations for Portuguese (Brasilian)
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
 # Generic
@@ -37,3 +37,8 @@ other = "{{ .Count }} Palavras"
 
 [lastModified]
 other = "Última actualização"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Entradas mais recentes"
+olderPosts = "Entradas mais antigas"

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} de cuvinte"
 
 [lastModified]
 other = "Ultima modificare"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Intrări mai noi"
+olderPosts = "Intrări mai vechi"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -41,3 +41,8 @@ other = "{{ .Count }} слов"
 
 [lastModified]
 other = "Последнее обновление"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Более новые записи"
+olderPosts = "Старые записи"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -1,4 +1,4 @@
-# Translations for English
+# Translations for Turkish
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
 # Generic

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }} Kelime"
 
 [lastModified]
 other = "Son güncelleme"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Daha yeni girişler"
+olderPosts = "Eski girişler"

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -41,3 +41,8 @@ other = "{{ .Count }} слів"
 
 [lastModified]
 other = "Останнє оновлення"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "Нові записи"
+olderPosts = "Старіші записи"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -37,3 +37,8 @@ other = "{{ .Count }}字"
 
 [lastModified]
 other = "最后修改"
+
+# partials/pagination-list.html
+[pagination]
+newerPosts = "较新条目"
+olderPosts = "旧条目"

--- a/layouts/partials/pagination-list.html
+++ b/layouts/partials/pagination-list.html
@@ -4,14 +4,14 @@
             <span class="button previous">
                 <a href="{{ .Paginator.Prev.URL }}">
                     <span class="button__icon">←</span>
-                    <span class="button__text">Newer posts</span>
+                    <span class="button__text">{{ i18n "pagination.newerPosts" }}</span>
                 </a>
             </span>
         {{ end }}
         {{ if .Paginator.HasNext }}
             <span class="button next">
                 <a href="{{ .Paginator.Next.URL }}">
-                    <span class="button__text">Older posts</span>
+                    <span class="button__text">{{ i18n "pagination.olderPosts" }}</span>
                     <span class="button__icon">→</span>
                 </a>
             </span>


### PR DESCRIPTION
Adds missing translations for the strings `Newer posts` and `Older posts`. Those buttons are currently not translated.

Added the German and English translation and some others on "best effort basis" - native speakers should double-check it. Wasn't able to translate to some languages though.

Fixes issue #441 