### PR TITLE
params.social is already used by _internal/twitter_cards.html partial

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -164,23 +164,23 @@ disableHugoGeneratorInject = false
   #   maxWidth = "50px"
 
   # Social icons
-  [[params.social]]
+  [[params.socialIcons]]
     name = "twitter"
     url  = "https://twitter.com/"
 
-  [[params.social]]
+  [[params.socialIcons]]
     name = "email"
     url  = "mailto:nobody@example.com"
 
-  [[params.social]]
+  [[params.socialIcons]]
     name = "github"
     url  = "https://github.com/"
 
-  [[params.social]]
+  [[params.socialIcons]]
     name = "linkedin"
     url  = "https://www.linkedin.com/"
 
-  [[params.social]]
+  [[params.socialIcons]]
     name = "stackoverflow"
     url  = "https://www.stackoverflow.com/"
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
 
             {{ partial "subtitle.html" . }}
 
-            {{- with .Site.Params.social }}
+            {{- with .Site.Params.socialIcons }}
                 <div>
                     {{ partial "social-icons.html" . }}
                 </div>


### PR DESCRIPTION
With Hugo `0.120` the builtin `_internal/twitter_cards.html` partial uses the `params.social` section by default, which is defined by this theme as a list of objects, but it is expected to be an object. I renamed the social icons section therefore to `socialIcons`

https://github.com/gohugoio/hugo/blob/4914b7f18c5007df8e74fe204e27114fc70812c8/tpl/tplimpl/embedded/templates/twitter_cards.html#L23-L32