### PR TITLE
Fix: Implement builtin localization for dates in blog list

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
     {{ $paginator := .Paginate .Data.Pages }}
-    
+
     <main class="posts">
         <h1>{{ .Title }}</h1>
 
@@ -19,9 +19,9 @@
                                 <span class="post-title">{{.Title}}</span>
                                 <span class="post-day">
                                     {{ if .Site.Params.dateformShort }}
-                                        {{ .Date.Format .Site.Params.dateformShort }}
+                                        {{ time.Format .Site.Params.dateformShort .Date }}
                                     {{ else }}
-                                        {{ .Date.Format "Jan 2"}}
+                                        {{ time.Format "Jan 2" .Date }}
                                     {{ end }}
                                 </span>
                             </a>


### PR DESCRIPTION
Currently, the blog list dates are hardcoded to the `defaultContentLanguage` option, typically set to English. Consequently, regardless of the selected language, dates are always displayed in English.

This PR fixes this using the builtin function `time.Format`, which returns the date as formatted and <ins>localized</ins> string.