### PR TITLE
adding SEO improvements

### DIFF
--- a/assets/scss/_fonts.scss
+++ b/assets/scss/_fonts.scss
@@ -1,7 +1,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  normal;
-  font-display: auto;
+  font-display: swap;
   font-weight: 400;
   src: url("fonts/Inter-Regular.woff2") format("woff2"),
        url("fonts/Inter-Regular.woff") format("woff");
@@ -9,7 +9,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  italic;
-  font-display: auto;
+  font-display: swap;
   font-weight: 400;
   src: url("fonts/Inter-Italic.woff2") format("woff2"),
        url("fonts/Inter-Italic.woff") format("woff");
@@ -18,7 +18,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  normal;
-  font-display: auto;
+  font-display: swap;
   font-weight: 600;
   src: url("fonts/Inter-Medium.woff2") format("woff2"),
        url("fonts/Inter-Medium.woff") format("woff");
@@ -26,7 +26,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  italic;
-  font-display: auto;
+  font-display: swap;
   font-weight: 600;
   src: url("fonts/Inter-MediumItalic.woff2") format("woff2"),
        url("fonts/Inter-MediumItalic.woff") format("woff");
@@ -35,7 +35,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  normal;
-  font-display: auto;
+  font-display: swap;
   font-weight: 800;
   src: url("fonts/Inter-Bold.woff2") format("woff2"),
        url("fonts/Inter-Bold.woff") format("woff");
@@ -43,7 +43,7 @@
 @font-face {
   font-family: "Inter";
   font-style:  italic;
-  font-display: auto;
+  font-display: swap;
   font-weight: 800;
   src: url("fonts/Inter-BoldItalic.woff2") format("woff2"),
        url("fonts/Inter-BoldItalic.woff") format("woff");

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-    <main aria-role="main">
+    <main>
         <div>
             {{ if .Site.Params.Portrait.Path }}
                <img src="{{ .Site.Params.Portrait.Path }}" class="circle" alt="{{ .Site.Params.Portrait.Alt }}" style="max-width:{{ .Site.Params.Portrait.MaxWidth }}" />


### PR DESCRIPTION
When running a Google Pagespeed Insight test on a site with the hugo theme 2 things are flagged by google.

1. ` [aria-*] attributes are not valid or misspelled `
This comes from the fact that the main tag in html sets "aria-role" which is not a valid attribute.
I chose to delete this attribute since tagging it with the same name has no accessibility benefits.

2. ` Ensure text remains visible during webfont load `
This can be fixed by setting the font-display to swap.

The PR fixes both issues. This might be of value to other people trying to improve the google ranking.
