### PR TITLE
add noindex meta parameter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -71,11 +71,6 @@
     {{ template "_internal/google_analytics.html" . }}
 {{- end }}
 
-<!-- Matomo Analytics -->
-{{- if .Site.Params.matomo.enable }}
-{{- partial "matomo.html" . }}
-{{- end }}
-
 <!-- Plausible.io -->
 {{- if $.Site.Params.plausibleDataDomain }}
     <script defer data-domain="{{ .Site.Params.plausibleDataDomain }}" src="{{ .Site.Params.plausibleScriptSource }}"></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,8 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
+{{ if .Params.noindex }}
+<meta name="robots" content="noindex" /> 
+{{ end }}
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="author" content="{{ if .Params.author }}{{ .Params.author }}{{ else }}{{ range .Site.Author }}{{ . }} {{ end }}{{ end }}">
 <meta name="description" content="{{ if .IsHome }}{{ .Site.Params.homeSubtitle }}{{ else }}{{ if .Params.Description }}{{ .Params.Description }}{{ else }}{{ .Summary | plainify }}{{ end }}{{ end }}" />
@@ -66,7 +69,12 @@
 <!-- Google Analytics internal template -->
 {{- if .Site.GoogleAnalytics }}
     {{ template "_internal/google_analytics.html" . }}
-{{- end}}
+{{- end }}
+
+<!-- Matomo Analytics -->
+{{- if .Site.Params.matomo.enable }}
+{{- partial "matomo.html" . }}
+{{- end }}
 
 <!-- Plausible.io -->
 {{- if $.Site.Params.plausibleDataDomain }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
 {{ if .Params.noindex }}
-<meta name="robots" content="noindex" /> 
+<meta name="robots" content="noindex" />
 {{ end }}
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="author" content="{{ if .Params.author }}{{ .Params.author }}{{ else }}{{ range .Site.Author }}{{ . }} {{ end }}{{ end }}">


### PR DESCRIPTION
This PR adds the possibility to set the `noindex` meta parameter in order to preventing search engine from indexing a particular post or page.

To enable it, the following line needs to be added to the front matter:

```yaml
noindex: true
```

Successfully tested on one of my websites.