### PR TITLE
Add option to not open the socials link on a new page

### DIFF
--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -1,3 +1,3 @@
 {{ range . -}}
-    &nbsp; <a href="{{ .url }}" target="_blank" rel="me noopener {{ .rel }}" title="{{ .name | humanize }}">{{ partial "svg.html" . }}</a> &nbsp;
+    &nbsp; <a href="{{ .url }}" {{if eq .nonewpage 0}} target="_blank" {{end}} rel="me noopener {{ .rel }}" title="{{ .name | humanize }}">{{ partial "svg.html" . }}</a> &nbsp;
 {{- end -}}


### PR DESCRIPTION
I've added a ``nonewpage`` parameter to social links to avoid popping them open on a new page. This is useful, for example, for adding an email page that is resistant to scraping.

As an example:
```
[[params.social]]
  name = "email"
  url  = "/email"
  nonewpage = true
```

Where /email.md is a page that says something like

```
+++
title = 'Want to email me?'
+++

The address is ``this domain`` at ``this domain`` dot ``this tld``
```