### PR TITLE
Upgraded deprecated features for `Hugo 0.127.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ paginate     = 10
 
 [languages]
   [languages.en]
-    title = "Hello Friend NG"
-    keywords = ""
-    copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
-    readOtherPosts = "Read other posts"
+    [languages.en.params]
+      title = "Hello Friend NG"
+      keywords = ""
+      copyright = '<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>'
+      readOtherPosts = "Read other posts"
 
-  [languages.en.params]
-    subtitle  = "A simple theme for Hugo"
+      subtitle  = "A simple theme for Hugo"
 
     [languages.en.params.logo]
       logoText = "hello friend ng"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -67,7 +67,7 @@
 {{- end }}
 
 <!-- Google Analytics internal template -->
-{{- if .Site.GoogleAnalytics }}
+{{- if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
 {{- end }}
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -122,7 +122,7 @@
 
     {{ partial "pagination-single.html" . }}
 
-    {{ if .Site.DisqusShortname }}
+    {{ if .Site.Config.Services.Disqus.Shortname }}
       {{ if not (eq .Params.Comments "false") }}
         <div id="comments">
           {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
I updated the following deprecated features and bugs that I found using this template.

```bash 
ERROR deprecated: config: languages.en.keywords: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.130.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
``` 
```bash 
WARN  deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.GoogleAnalytics.ID instead.
```
```bash
WARN  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```

Fixes #476 and #457 