### PR TITLE
Make top menu order consistent across localizations.

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 <nav class="menu">
     <ul class="menu__inner">
         {{- $currentPage := . -}}
-        {{ range .Site.Menus.main -}}
+        {{ range sort .Site.Menus.main ".Identifier" -}}
             <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
         {{- end }}
 


### PR DESCRIPTION
Fixes #479 by sorting menu items by their "identifier parameter". I'm not experienced as a Hugo developer, so this may break things or need extra code (i.e: maybe a fallback if there is no identifier? or is identifier mandatory? idk)