### PR TITLE
Fix #484 - .Site.Config.Services.Disqus.Shortname

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -122,7 +122,7 @@
 
     {{ partial "pagination-single.html" . }}
 
-    {{ if .Site.DisqusShortname }}
+    {{ if .Site.Config.Services.Disqus.Shortname }}
       {{ if not (eq .Params.Comments "false") }}
         <div id="comments">
           {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
Update `.Site.DisqusShortname` to `.Site.Config.Services.Disqus.Shortname`