### PR TITLE
Fix contrast issue in code blocks on light mode

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -210,7 +210,7 @@ em, i, strong {
   }
 }
 
-code {
+> code {
   font-family: Consolas, Monaco, Andale Mono, Ubuntu Mono, monospace;
   font-display: auto;
   font-feature-settings: normal;
@@ -257,7 +257,7 @@ pre {
     word-wrap: break-word;
   }
 
-  code {
+  > .code {
     background: none !important;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
This uses the child combinator selector > to make sure the `pre > code` block doesn't override the top-level `code` block unintentionally.

Closes #364.