### PR TITLE
Revert "sort top menu items by identifier"

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 <nav class="menu">
     <ul class="menu__inner">
         {{- $currentPage := . -}}
-        {{ range sort .Site.Menus.main ".Identifier" -}}
+        {{ range .Site.Menus.main -}}
             <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
         {{- end }}
 


### PR DESCRIPTION
This reverts commit e78a00ee84e1635d54231fc8b37a087c05fa62d2, which broke menu sorting.

#508 