### PR TITLE
fix(menu): sort menu items by weight instead of identifier

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 <nav class="menu">
     <ul class="menu__inner">
         {{- $currentPage := . -}}
-        {{ range sort .Site.Menus.main ".Weight" -}}
+        {{ range .Site.Menus.main.ByWeight -}}
             {{ if .HasChildren }}
                 <div class="submenu">
                     <li class="dropdown">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 <nav class="menu">
     <ul class="menu__inner">
         {{- $currentPage := . -}}
-        {{ range sort .Site.Menus.main ".Identifier" -}}
+        {{ range sort .Site.Menus.main ".Weight" -}}
             {{ if .HasChildren }}
                 <div class="submenu">
                     <li class="dropdown">


### PR DESCRIPTION
## Summary

- Fixes menu items being sorted alphabetically by identifier instead of by `weight`
- Replaces `sort .Site.Menus.main ".Identifier"` with `.Site.Menus.main.ByWeight` in `layouts/partials/menu.html`
- `.ByWeight` sorts by weight and falls back to identifier for items with equal or unset weight

## Related issue

Closes #525

## Test plan

- [ ] Set different `weight` values on menu items in `config.toml`
- [ ] Verify menu renders in weight order (lower weight = first)
- [ ] Verify menu items without `weight` set fall back to alphabetical order by identifier